### PR TITLE
Group function update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ##Pure
 <img align="right" src="https://raw.githubusercontent.com/go-playground/pure/master/logo.png">
-![Project status](https://img.shields.io/badge/version-3.1.1-green.svg)
+![Project status](https://img.shields.io/badge/version-4.0.0-green.svg)
 [![Build Status](https://semaphoreci.com/api/v1/joeybloggs/pure/branches/master/badge.svg)](https://semaphoreci.com/joeybloggs/pure)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/pure/badge.svg?branch=master)](https://coveralls.io/github/go-playground/pure?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/pure)](https://goreportcard.com/report/github.com/go-playground/pure)

--- a/group.go
+++ b/group.go
@@ -11,7 +11,7 @@ type IRouteGroup interface {
 	IRoutes
 	GroupWithNone(prefix string) IRouteGroup
 	GroupWithMore(prefix string, middleware ...Middleware) IRouteGroup
-	GroupWithExisting(prefix string) IRouteGroup
+	Group(prefix string) IRouteGroup
 }
 
 // IRoutes interface for routes
@@ -167,8 +167,8 @@ func (g *routeGroup) GroupWithMore(prefix string, middleware ...Middleware) IRou
 	return rg
 }
 
-// GroupWithExisting creates a new sub router with specified prefix and retains existing middleware.
-func (g *routeGroup) GroupWithExisting(prefix string) IRouteGroup {
+// Group creates a new sub router with specified prefix and retains existing middleware.
+func (g *routeGroup) Group(prefix string) IRouteGroup {
 
 	rg := &routeGroup{
 		prefix:     g.prefix + prefix,

--- a/group_test.go
+++ b/group_test.go
@@ -46,7 +46,7 @@ func TestUseAndGroup(t *testing.T) {
 	Equal(t, body, http.MethodGet)
 	Equal(t, log, "/")
 
-	g := p.Group("/users")
+	g := p.GroupWithExisting("/users")
 	g.Get("/", fn)
 	g.Get("/list/", fn)
 
@@ -67,7 +67,7 @@ func TestUseAndGroup(t *testing.T) {
 		}
 	}
 
-	sh := p.Group("/superheros", logger2)
+	sh := p.GroupWithMore("/superheros", logger2)
 	sh.Get("/", fn)
 	sh.Get("/list/", fn)
 
@@ -81,7 +81,7 @@ func TestUseAndGroup(t *testing.T) {
 	Equal(t, body, http.MethodGet)
 	Equal(t, log, "/superheros/list/2")
 
-	sc := sh.Group("/children")
+	sc := sh.GroupWithExisting("/children")
 	sc.Get("/", fn)
 	sc.Get("/list/", fn)
 
@@ -97,7 +97,7 @@ func TestUseAndGroup(t *testing.T) {
 
 	log = ""
 
-	g2 := p.Group("/admins", nil)
+	g2 := p.GroupWithNone("/admins")
 	g2.Get("/", fn)
 	g2.Get("/list/", fn)
 

--- a/group_test.go
+++ b/group_test.go
@@ -46,7 +46,7 @@ func TestUseAndGroup(t *testing.T) {
 	Equal(t, body, http.MethodGet)
 	Equal(t, log, "/")
 
-	g := p.GroupWithExisting("/users")
+	g := p.Group("/users")
 	g.Get("/", fn)
 	g.Get("/list/", fn)
 
@@ -81,7 +81,7 @@ func TestUseAndGroup(t *testing.T) {
 	Equal(t, body, http.MethodGet)
 	Equal(t, log, "/superheros/list/2")
 
-	sc := sh.GroupWithExisting("/children")
+	sc := sh.Group("/children")
 	sc.Get("/", fn)
 	sc.Get("/list/", fn)
 


### PR DESCRIPTION
#### What Changed?
- It used to be that the `Group` function handled 3 different scenarios:
1. `.Group("/users")` - group with existing middleware
2. `.Group("/users", nil)` - group but retain no middleware
3. `.Group("/users", MoreMiddleware)` - group, retain existing and add MoreMiddleware

This was confusing and even I was always referring to the function to remember what it all did so here is how it works now.

1. `.Group("/users")` - group with existing middleware
2. `.GroupWithNone("/users")` - group but retain no middleware.
3. `.GroupWithMore("/users", MoreMiddleware)` - group, retain existing and add MoreMiddleware